### PR TITLE
add "copy design url" feature

### DIFF
--- a/src/lib/Param.svelte
+++ b/src/lib/Param.svelte
@@ -10,7 +10,7 @@
 
 <label>
 	<input type="number" autocomplete="off" bind:value {min} {max} {step} />
-	<input type="range" autocomplete="off" {min} {max} {step} />
+	<input type="range" autocomplete="off" bind:value {min} {max} {step} />
 	{label}
 </label>
 

--- a/src/lib/Param.svelte
+++ b/src/lib/Param.svelte
@@ -9,8 +9,8 @@
 </script>
 
 <label>
-	<input type="number" bind:value {min} {max} {step} />
-	<input type="range" bind:value {min} {max} {step} />
+	<input type="number" autocomplete="off" bind:value {min} {max} {step} />
+	<input type="range" autocomplete="off" {min} {max} {step} />
 	{label}
 </label>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -38,14 +38,22 @@
 	onMount(() => {
 		let data = JSON.parse(atob(window.location.hash.substring(1)));
 
+		console.log(data);
+
 		hue = data.hue;
 		chroma = data.chroma;
 		opacity = data.opacity;
 		lightness = data.lightness;
 	});
 
-	function copyHash() {
+	$effect(() => {
 		window.location.hash = hash;
+		// fix weird issues with lightness not changing hash
+		lightness.light = lightness.light;
+		lightness.dark = lightness.dark;
+	});
+
+	function copyHash() {
 		window.navigator.clipboard.writeText(window.location.href);
 	}
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import Param from '$lib/Param.svelte';
 	import { debounce } from '$lib/utils';
+	import { onMount } from 'svelte';
 
 	let hue = $state({
 		count: 5,
@@ -33,6 +34,20 @@
 	});
 
 	let hash = $derived(btoa(JSON.stringify({ hue, chroma, opacity, lightness })));
+
+	onMount(() => {
+		let data = JSON.parse(atob(window.location.hash.substring(1)));
+
+		hue = data.hue;
+		chroma = data.chroma;
+		opacity = data.opacity;
+		lightness = data.lightness;
+	});
+
+	function copyHash() {
+		window.location.hash = hash;
+		window.navigator.clipboard.writeText(window.location.href);
+	}
 
 	$inspect(hash);
 
@@ -177,6 +192,12 @@
 			max={0.15}
 			step={0.001}
 		/>
+		<h1>sharing</h1>
+		<button
+			onclick={() => {
+				copyHash();
+			}}>copy design url</button
+		>
 	</div>
 	<div>
 		<h1>light mode</h1>


### PR DESCRIPTION
A much leaner version of my previous PR. Uses the `hash` `$derived` value, and converts it back to the right JSON values at runtime. 

Press the button to copy the URL which, when visited, will automatically set the design parameters on page load.